### PR TITLE
Add support for `npm init`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 create-ember-app
 ==============================================================================
 
-```
+```sh
 yarn create ember-app <name>
+```
+
+or if you have npm@6.1 or later:
+
+```sh
+npm init ember-app <name>
 ```
 
 This is a small wrapper for [Ember CLI](https://github.com/ember-cli/ember-cli)

--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
 var execa = require('execa');
+var whoRanMe = require('who-ran-me');
 
 var args = ['new'];
 
-if (process.env._ && !process.env._.match(/(npx|npm)$/)) {
+if (whoRanMe() === 'yarn') {
   args.push('--yarn');
 }
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ var whoRanMe = require('who-ran-me');
 
 var args = ['new'];
 
-if (whoRanMe() === 'yarn') {
+// yarn reports the bin script from who-ran-me
+if (['yarn', 'create-ember-app'].includes(whoRanMe())) {
   args.push('--yarn');
 }
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var execa = require('execa');
 
-var args = ['new', '--yarn'];
+var args = ['new'];
 for (var i = 2; i < process.argv.length; i++) {
   args.push(process.argv[i]);
 }

--- a/index.js
+++ b/index.js
@@ -3,6 +3,11 @@
 var execa = require('execa');
 
 var args = ['new'];
+
+if (process.env._ && !process.env._.match(/(npx|npm)$/)) {
+  args.push('--yarn');
+}
+
 for (var i = 2; i < process.argv.length; i++) {
   args.push(process.argv[i]);
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   "dependencies": {
     "ember-cli": "^3.1.2",
     "execa": "^0.10.0",
-    "who-ran-me": "^1.0.0"
+    "who-ran-me": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "keywords": [
     "ember",
     "ember-cli",
-    "yarn"
+    "yarn",
+    "npm"
   ],
   "homepage": "https://github.com/ember-cli/create-ember-app#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "ember-cli": "^3.1.2",
-    "execa": "^0.10.0"
+    "execa": "^0.10.0",
+    "who-ran-me": "^1.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4495,6 +4495,11 @@ which@^1.2.9, which@^1.3.0:
   dependencies:
     isexe "^2.0.0"
 
+who-ran-me@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/who-ran-me/-/who-ran-me-1.0.0.tgz#06e4bf9f0956eeeb3a309a5c9a6fefb3fd31c7b3"
+  integrity sha512-VFHFILrI2t01/dfG/yKQerTPkvmdmXCbwUXe7dyIVr3wxrX+c+HLroQ8q0cBtpv0UPDls8Jrd2z2ATtO0m3EYQ==
+
 wide-align@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4495,10 +4495,10 @@ which@^1.2.9, which@^1.3.0:
   dependencies:
     isexe "^2.0.0"
 
-who-ran-me@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/who-ran-me/-/who-ran-me-1.0.0.tgz#06e4bf9f0956eeeb3a309a5c9a6fefb3fd31c7b3"
-  integrity sha512-VFHFILrI2t01/dfG/yKQerTPkvmdmXCbwUXe7dyIVr3wxrX+c+HLroQ8q0cBtpv0UPDls8Jrd2z2ATtO0m3EYQ==
+who-ran-me@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/who-ran-me/-/who-ran-me-1.0.2.tgz#00b8c4779479d31b70c6696601991834dd69e394"
+  integrity sha512-G5ZDlU8bSEn6beXjkMeN9bmWl+Lln5PNnJ5YY2VDcwe8zR/RKryQLp108bD0Kl7q81ejUuYyNXkIMIypIp70Xg==
 
 wide-align@^1.1.0:
   version "1.1.2"


### PR DESCRIPTION
I'm not sure if everyone is aware but npm is in the process of releasing npm@6 which has native support for `npm init` that is specifically supposed to work like `yarn create`.

<img height="400" alt="screen shot 2018-04-21 at 09 25 57" src="https://user-images.githubusercontent.com/594890/39082136-2bc7f0ec-4546-11e8-8e4e-6d5830dcda41.png">

[link to above tweet](https://twitter.com/maybekatz/status/986722059706224640)

This PR is a **super** niave way of fixing the experience for npm users that dont have yarn installed. If you want to try it out now you can run the following command: 

```
npx npm@v6.0.0-next.2 init stonecircle-ember my-app
```

I had to publish a temporary npm package `create-stonecircle-ember` because of [this bug](https://github.com/npm/npm/issues/20399) with the implementation. It is beta after all 😉 

I would like to evolve this PR to be able to tell if it's being executed via npm or yarn and include the `--yarn` parameter programatically but I'm not exactly sure the best way to tackle that 🤔